### PR TITLE
fix: Complilation errors on ROS versions older than Iron

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+IF("$ENV{ROS_DISTRO}" STRLESS "iron")
+  add_definitions(-DPRE_ROS_IRON)
+ENDIF()
+
 # Set common compile options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -fexceptions")
 

--- a/include/LIVMapper.h
+++ b/include/LIVMapper.h
@@ -16,7 +16,11 @@ which is included as part of this source code package.
 #include "IMU_Processing.h"
 #include "vio.h"
 #include "preprocess.h"
+#ifdef PRE_ROS_IRON
+#include <cv_bridge/cv_bridge.h>
+#else
 #include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>


### PR DESCRIPTION
For ROS versions older than iron `cv_bridge.h` needs to be used instead of `cv_bridge.hpp`. This PR introduces an CMake definition to correctly import `cv_bridge` based on the `ROS_DISTRO` environment variable.

Implementation inspired by RTABMAP: https://github.com/introlab/rtabmap_ros/commit/911e4e89412c9658d569c0258730cb386b493d77